### PR TITLE
take snapshot by event name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 
 before_script:
   - composer self-update
-  - composer --dev install
+  - composer --dev install --prefer-source
 
 script:
   - php ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml

--- a/composer.json
+++ b/composer.json
@@ -56,5 +56,14 @@
             "ProophTest\\Snapshotter\\": "tests/",
             "ProophTest\\EventStore\\": "vendor/prooph/event-store/tests/"
         }
+    },
+    "scripts": {
+        "check": [
+            "@cs",
+            "@test"
+        ],
+        "cs": "php-cs-fixer fix -v --diff --dry-run",
+        "cs-fix": "php-cs-fixer fix -v --diff",
+        "test": "phpunit"
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,9 @@
 # Configuration
  
 To enable the Snapshot-Plugin simply attach it as plugin to the event-store. 
-It needs a list of aggregate root => aggregate repositories and a version step.
-Version step 5 f.e. means take a snapshot every 5 versions.
+It needs a list of aggregate root => aggregate repositories and a version step and/or a list of event names.
+Version step 5 f.e. means take a snapshot every 5 versions. If event names provided, snaphosts also taken if one of 
+these events occurred.
 If you use the provided factories from event-store and the snapshotter, you can simply do this by configuration:
 
     return [
@@ -14,6 +15,7 @@ If you use the provided factories from event-store and the snapshotter, you can 
             ],
             'snapshotter' => [
                 'version_step' => 5,
+                'event_names' => ['awesomeEvent'],
                 'aggregate_repositories' => [
                     'My\Domain\AggregateRoot' => \My\Domain\AggregateRootRepository::class,
                 ]

--- a/src/Container/SnapshotPluginFactory.php
+++ b/src/Container/SnapshotPluginFactory.php
@@ -36,7 +36,7 @@ final class SnapshotPluginFactory implements RequiresConfig, RequiresMandatoryOp
         $config = $container->get('config');
         $config = $this->options($config);
 
-        return new SnapshotPlugin($container->get(CommandBus::class), $config['version_step']);
+        return new SnapshotPlugin($container->get(CommandBus::class), $config['version_step'], $config['event_names']);
     }
 
     /**
@@ -53,7 +53,8 @@ final class SnapshotPluginFactory implements RequiresConfig, RequiresMandatoryOp
     public function defaultOptions()
     {
         return [
-            'version_step' => 5
+            'version_step' => 5,
+            'event_names' => [],
         ];
     }
 

--- a/tests/Container/SnapshotPluginFactoryTest.php
+++ b/tests/Container/SnapshotPluginFactoryTest.php
@@ -35,12 +35,25 @@ final class SnapshotPluginFactoryTest extends TestCase
             'prooph' => [
                 'snapshotter' => [
                     'version_step' => 5,
-                ]
-            ]
+                    'event_names' => ['awesomeEvent'],
+                ],
+            ],
         ]);
         $container->get(CommandBus::class)->willReturn($commandBus->reveal());
 
         $factory = new SnapshotPluginFactory();
-        $this->assertInstanceOf(SnapshotPlugin::class, $factory($container->reveal()));
+        $snapshotPlugin =  $factory($container->reveal());
+
+        $this->assertInstanceOf(SnapshotPlugin::class, $snapshotPlugin);
+
+        $reflectionClass = new \ReflectionClass($snapshotPlugin);
+        $versionStepProperty = $reflectionClass->getProperty('versionStep');
+        $versionStepProperty->setAccessible(true);
+        $eventNamesProperty = $reflectionClass->getProperty('eventNames');
+        $eventNamesProperty->setAccessible(true);
+
+        $this->assertSame(5, $versionStepProperty->getValue($snapshotPlugin));
+        $this->assertArrayHasKey(0, $eventNamesProperty->getValue($snapshotPlugin));
+        $this->assertSame('awesomeEvent', $eventNamesProperty->getValue($snapshotPlugin)[0]);
     }
 }


### PR DESCRIPTION
If you have big events sometime, it would be useful to create also a snapshot if this event occurs. I want to discuss this feature, before I complete it. 

The reason against to create a new plugin e.g. `SnapshotEventNamePlugin` is, that if the event name occurs at the same time if version step is reached, two snapshosts will be executed. And maybe to avoid performance issues because of double checks. I see no possibility to stop propagation, because other plugins can be exists.
- [x] Add/Fix unit tests
- [x] Update docs
