### PR TITLE
Restructure docs

### DIFF
--- a/docs/bookdown.json
+++ b/docs/bookdown.json
@@ -1,9 +1,10 @@
 {
-  "title": "Prooph EventSourcing",
+  "title": "Snapshotter",
   "content": [
-    {"intro": "../README.md"},
     {"snapshots": "snapshots.md"}
   ],
+  "tocDepth": 1,
+  "numbering": false,
   "target": "./html",
   "template": "../vendor/prooph/bookdown-template/templates/main.php"
 }

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -1,5 +1,15 @@
 # Snapshotter
 
+Snapshot tool for the prooph event-store. Take aggregate snapshots with ease.
+
+## Installation
+
+```
+composer require prooph/snapshotter
+```
+
+## Snapshots via Projection
+
 There are two projections shipped with this package:
 
 1) CategorySnapshotProjection


### PR DESCRIPTION
According to https://github.com/prooph/proophessor/issues/38#issuecomment-336200542

- shorter headlines
- introduction instead of using entire README (better overview while browsing through the docs)