### PR TITLE
Fixes unlimited memory consumption by clearing identityMap

### DIFF
--- a/src/SnapshotReadModel.php
+++ b/src/SnapshotReadModel.php
@@ -103,6 +103,7 @@ final class SnapshotReadModel implements ReadModel
             ));
         }
 
+        $this->aggregateRepository->clearIdentityMap();
         $this->aggregateCache = [];
     }
 


### PR DESCRIPTION
Fixes unlimited memory consumption by clearing identityMap of AggregateRepository after saving shapshots to ShapshotStore