### PR TITLE
Add snapshot interface

### DIFF
--- a/src/SnapshotCommand.php
+++ b/src/SnapshotCommand.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * This file is part of prooph/snapshotter.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 11/02/15 - 03:52 PM
+ */
+
+namespace Prooph\Snapshotter;
+
+use Prooph\Common\Messaging\Message;
+
+interface SnapshotCommand extends Message
+{
+    /**
+     * @return string
+     */
+    public function aggregateType();
+
+    /**
+     * @return string
+     */
+    public function aggregateId();
+}

--- a/src/Snapshotter.php
+++ b/src/Snapshotter.php
@@ -51,10 +51,10 @@ final class Snapshotter
     }
 
     /**
-     * @param TakeSnapshot $command
+     * @param SnapshotCommand $command
      * @throws Exception\RuntimeException
      */
-    public function __invoke(TakeSnapshot $command)
+    public function __invoke(SnapshotCommand $command)
     {
         $aggregateType = $command->aggregateType();
 

--- a/src/TakeSnapshot.php
+++ b/src/TakeSnapshot.php
@@ -19,7 +19,7 @@ use Prooph\Common\Messaging\PayloadTrait;
  * Class TakeSnapshot
  * @package Prooph\Snapshotter
  */
-final class TakeSnapshot extends Command
+final class TakeSnapshot extends Command implements SnapshotCommand
 {
     use PayloadTrait;
 


### PR DESCRIPTION
**This is for version 1.x**

I want to create manually snapshots via CLI and I've ~ 30k Ids and each aggregate id has ~ 250 events. This takes a while so I need async support. I don't want to route all snapshot commands to an async message producer.

This PR adds an interface so I can define my own async snapshot command:

```php
final class TakeSnapshotAsync extends Command implements SnapshotCommand, AsyncMessage
{
    // ...
}
```